### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 Atom.io grammar for [nearley](https://github.com/Hardmath123/nearley).
 
 ![screenshot](https://cloud.githubusercontent.com/assets/5276727/9818196/e6312740-58af-11e5-830f-3a6649947de1.png)
+
+
+[![Run on Repl.it](https://repl.it/badge/github/drjoeavg/nearley-grammar)](https://repl.it/github/drjoeavg/nearley-grammar)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).